### PR TITLE
Update adms.rb

### DIFF
--- a/adms.rb
+++ b/adms.rb
@@ -25,6 +25,6 @@ class Adms < Formula
 
   bottle do
     root_url "https://dl.bintray.com/guitorri/homebrew-tap"
-    sha256 "49bf86f2750ce1d97f750e4287ef181e6bc10e8bf5de5fe045027e6918f969fc" => :sierra
+    sha256 tag: "49bf86f2750ce1d97f750e4287ef181e6bc10e8bf5de5fe045027e6918f969fc" => :sierra
   end
 end


### PR DESCRIPTION
fix warning:

Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.